### PR TITLE
Feature/use async apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project provides a bridge between Hasura's PromptQL data agent and AI assis
 ### Prerequisites
 
 - Python 3.10 or higher
-- A Hasura PromptQL project with API key and DDN URL
+- A Hasura PromptQL project with API key, playground URL, and DDN Auth Token
 - Claude Desktop (for interactive use) or any MCP-compatible client
 
 ### Install from Source
@@ -49,7 +49,7 @@ pip install -e .
 1. Configure your PromptQL credentials:
 
 ```bash
-python -m promptql_mcp_server setup --api-key YOUR_PROMPTQL_API_KEY --ddn-url YOUR_DDN_URL
+python -m promptql_mcp_server setup --api-key YOUR_PROMPTQL_API_KEY --playground-url YOUR_PLAYGROUND_URL --auth-token YOUR_AUTH_TOKEN
 ```
 
 2. Test the server:
@@ -116,7 +116,7 @@ where python  # On Windows
 ### Tools
 The server exposes the following MCP tools:
 - **ask_question** - Ask natural language questions about your data
-- **setup_config** - Configure PromptQL API key and DDN URL
+- **setup_config** - Configure PromptQL API key, playground URL, and DDN Auth Token
 - **check_config** - Verify the current configuration status
 
 ### Prompts

--- a/examples/simple_client.py
+++ b/examples/simple_client.py
@@ -3,6 +3,8 @@ import traceback
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+
+
 async def main():
     """Simple example client for PromptQL MCP server."""
     
@@ -45,23 +47,312 @@ async def main():
                     })
                     print(f"Configuration result: {result}")
             
-                # Ask a question
-                while True:
-                    question = input("\nEnter a question to ask PromptQL (or 'exit' to quit): ")
-                    if question.lower() == 'exit':
-                        break
-                
-                    print("Asking question...")
-                    result = await client.call_tool("ask_question", {
-                        "question": question
-                    })
-                
-                    print("\nAnswer:")
-                    print(result)
+                # Choose interaction mode
+                print("\nChoose interaction mode:")
+                print("1. Multi-turn conversation (thread-based)")
+                print("2. Thread management demo")
+                print("3. Thread cancellation demo")
+                print("4. Start thread without polling demo")
+                mode = input("Enter choice (1, 2, 3, or 4): ").strip()
+
+                if mode == "1":
+                    await multi_turn_conversation(client)
+                elif mode == "2":
+                    await thread_management_demo(client)
+                elif mode == "3":
+                    await thread_cancellation_demo(client)
+                elif mode == "4":
+                    await start_thread_without_polling_demo(client)
+                else:
+                    print("Invalid choice. Using multi-turn conversation mode.")
+                    await multi_turn_conversation(client)
 
     except Exception as e:
         print(f"Error occurred: {e}")
-        print(traceback.format_exc())  
+        print(traceback.format_exc())
+
+
+
+async def multi_turn_conversation(client):
+    """Demonstrate multi-turn conversation using thread management."""
+    print("\n" + "="*80)
+    print("MULTI-TURN CONVERSATION MODE")
+    print("="*80)
+    print("This mode allows you to have a conversation with PromptQL where")
+    print("each question builds on the previous context.")
+    print("Type 'quit' to exit, 'status' to check thread status, 'cancel' to cancel processing.")
+    print("="*80)
+
+    thread_id = None
+    conversation_count = 0
+
+    while True:
+        if thread_id is None:
+            # Start a new thread
+            question = input(f"\n[Question {conversation_count + 1}] Enter your first question: ").strip()
+            if not question:
+                print("No question provided.")
+                continue
+
+            if question.lower() == 'quit':
+                break
+
+            print(f"\n🚀 Starting new thread...")
+            result = await client.call_tool("start_thread", {"message": question})
+            print(f"Result: {result}")
+
+            # Access result directly without extract_result_text
+            if hasattr(result, 'content') and result.content and result.content[0].text:
+                result_text = result.content[0].text
+
+                if "Thread ID:" in result_text:
+                    thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
+                    conversation_count += 1
+                    print(f"✅ Thread started with ID: {thread_id}")
+
+                    # Display the complete response (start_thread now waits for completion)
+                    print(f"\n📝 Response:")
+                    print(result_text)
+                else:
+                    print("❌ Failed to start thread")
+                    continue
+            else:
+                print("❌ Failed to start thread")
+                continue
+        else:
+            # Continue the existing thread
+            question = input(f"\n[Question {conversation_count + 1}] Continue conversation (or 'quit'/'status'): ").strip()
+            if not question:
+                continue
+
+            if question.lower() == 'quit':
+                break
+            elif question.lower() == 'status':
+                status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+                print(f"📊 Thread status: {status_result}")
+                continue
+
+            print(f"\n💬 Continuing thread {thread_id}...")
+            result = await client.call_tool("continue_thread", {
+                "thread_id": thread_id,
+                "message": question
+            })
+            conversation_count += 1
+            print(f"\n📝 Response:")
+            print(result)
+
+    if thread_id:
+        print(f"\n🏁 Conversation ended. Final thread ID: {thread_id}")
+        print(f"📈 Total questions asked: {conversation_count}")
+
+        # Get final status
+        final_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+        print(f"📊 Final thread status: {final_status}")
+
+async def thread_management_demo(client):
+    """Demonstrate thread management capabilities using continue_thread."""
+    print("\n" + "="*80)
+    print("THREAD MANAGEMENT DEMO")
+    print("="*80)
+    print("This demo shows how to use continue_thread to build conversations.")
+    print("We'll start one thread and continue it with multiple related questions.")
+    print("="*80)
+
+    # Start the initial thread
+    initial_question = "What tables are available in my database?"
+    print(f"\n🚀 Starting thread with: {initial_question}")
+
+    result = await client.call_tool("start_thread", {"message": initial_question})
+    print(f"Start result: {result}")
+
+    # Access result directly without extract_result_text
+    if hasattr(result, 'content') and result.content and result.content[0].text:
+        result_text = result.content[0].text
+
+        if "Thread ID:" in result_text:
+            thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
+            print(f"✅ Thread started with ID: {thread_id}")
+
+            # Display the complete initial response (start_thread now waits for completion)
+            print(f"\n📝 Initial Response:")
+            print(result_text)
+
+        # Continue with related questions using the same thread
+        follow_up_questions = [
+            "Tell me more about the largest table you found",
+            "Show me the schema of that table",
+            "How many records are in that table?",
+            "Can you show me a sample of data from it?"
+        ]
+
+        print(f"\n🔄 Continuing thread with {len(follow_up_questions)} follow-up questions...")
+
+        for i, question in enumerate(follow_up_questions, 1):
+            print(f"\n--- Follow-up {i} ---")
+            print(f"Question: {question}")
+
+            # Check status before asking the follow-up question
+            print("📊 Checking thread status before continuing...")
+            pre_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+            print(f"Pre-continue status: {pre_status}")
+
+            # Use continue_thread to maintain context
+            continue_result = await client.call_tool("continue_thread", {
+                "thread_id": thread_id,
+                "message": question
+            })
+            print(f"Continue result: {continue_result}")
+
+            # Check status after each continuation
+            status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+            print(f"📊 Post-continue status: {status_result}")
+
+            # Small delay between questions
+            await asyncio.sleep(2)
+
+        print(f"\n🏁 Demo completed. Used continue_thread {len(follow_up_questions)} times on thread {thread_id[:8]}...")
+
+    else:
+        print("❌ Failed to start initial thread")
+
+    print("\nKey benefits of continue_thread:")
+    print("- Maintains conversation context across questions")
+    print("- More efficient than creating new threads")
+    print("- Allows for natural follow-up questions")
+    print("- Thread remembers previous answers and context")
+
+async def thread_cancellation_demo(client):
+    """Demonstrate thread cancellation functionality."""
+    print("\n" + "="*80)
+    print("THREAD CANCELLATION DEMO")
+    print("="*80)
+    print("This demo shows how to cancel thread processing while it's running.")
+    print("We'll start a thread without polling and then cancel it during processing.")
+    print("="*80)
+
+    # Start a thread with a complex question that will take time to process
+    complex_question = "Analyze all tables in my database, show their relationships, and provide detailed statistics for each table including row counts, column types, and data quality metrics."
+
+    print(f"\n🚀 Starting thread without polling...")
+    print(f"Question: {complex_question}")
+
+    result = await client.call_tool("start_thread_without_polling", {"message": complex_question})
+    print(f"Start result: {result}")
+
+    # Access result directly without extract_result_text
+    if hasattr(result, 'content') and result.content and result.content[0].text:
+        result_text = result.content[0].text
+
+        if "Thread ID:" in result_text:
+            thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
+            print(f"✅ Thread started with ID: {thread_id}")
+
+            # Display the immediate response (should just be thread info)
+            print(f"\n📝 Immediate Response:")
+            print(result_text)
+
+        # Give the thread a moment to start processing
+        print("\n⏳ Waiting 3 seconds for processing to begin...")
+        await asyncio.sleep(3)
+
+        # Check status (should be processing)
+        print("\n📊 Checking thread status...")
+        status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+        print(f"Status: {status_result}")
+
+        # Attempt to cancel while processing
+        print(f"\n🛑 Attempting to cancel thread {thread_id} while processing...")
+        cancel_result = await client.call_tool("cancel_thread", {"thread_id": thread_id})
+        print(f"Cancel result: {cancel_result}")
+
+        # Check status after cancellation
+        print("\n📊 Checking thread status after cancellation...")
+        final_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+        print(f"Final status: {final_status}")
+
+        # Try to cancel again (should fail since it's no longer processing)
+        print(f"\n🛑 Attempting to cancel again (should fail)...")
+        second_cancel = await client.call_tool("cancel_thread", {"thread_id": thread_id})
+        print(f"Second cancel result: {second_cancel}")
+
+    else:
+        print("❌ Failed to start thread")
+
+    print(f"\n🏁 Cancellation demo completed.")
+    print("\nKey points about thread cancellation:")
+    print("- Use start_thread_without_polling to enable cancellation during processing")
+    print("- Can only cancel threads that are currently processing")
+    print("- Cancellation stops the latest interaction in the thread")
+    print("- Attempting to cancel a completed/cancelled thread will fail")
+    print("- Cancelled threads can potentially be continued with new messages")
+
+async def start_thread_without_polling_demo(client):
+    """Demonstrate starting a thread without polling for completion."""
+    print("\n" + "="*60)
+    print("🚀 START THREAD WITHOUT POLLING DEMO")
+    print("="*60)
+    print("This demo shows how to start a thread and manually check its status.")
+
+    # Start a thread without waiting for completion
+    question = "What are the top 3 largest tables in my database? Include row counts and sizes."
+
+    print(f"\n🚀 Starting thread without polling...")
+    print(f"Question: {question}")
+
+    result = await client.call_tool("start_thread_without_polling", {"message": question})
+    print(f"Start result: {result}")
+
+    # Access result directly without extract_result_text
+    if hasattr(result, 'content') and result.content and result.content[0].text:
+        result_text = result.content[0].text
+
+        if "Thread ID:" in result_text:
+            thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
+            print(f"✅ Thread started with ID: {thread_id}")
+
+            # Display the immediate response (should just be thread info)
+            print(f"\n📝 Immediate Response:")
+            print(result_text)
+
+        # Now manually check status multiple times
+        print(f"\n📊 Manually checking thread status...")
+
+        for i in range(5):  # Check up to 5 times
+            print(f"\n--- Status Check {i+1} ---")
+            status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+            print(f"Status: {status_result}")
+
+            # Check if the status indicates completion
+            if hasattr(status_result, 'content') and status_result.content and status_result.content[0].text:
+                status_text = status_result.content[0].text
+                if '"status": "complete"' in status_text or 'status: complete' in status_text.lower():
+                    print("✅ Thread completed!")
+                    break
+            else:
+                print("⏳ Thread still processing, waiting 3 seconds...")
+                await asyncio.sleep(3)
+        else:
+            print("⏰ Stopped checking after 5 attempts")
+
+        # Try to continue the thread
+        print(f"\n💬 Continuing thread with follow-up question...")
+        follow_up = "Can you show me the schema of the largest table?"
+        continue_result = await client.call_tool("continue_thread", {
+            "thread_id": thread_id,
+            "message": follow_up
+        })
+        print(f"Continue result: {continue_result}")
+
+    else:
+        print("❌ Failed to start thread")
+
+    print(f"\n🏁 Start without polling demo completed.")
+    print("\nKey points about starting without polling:")
+    print("- Returns thread_id and interaction_id immediately")
+    print("- Thread processing happens asynchronously")
+    print("- Use get_thread_status to check progress")
+    print("- Can continue threads even while they're processing")
+    print("- Useful for non-blocking workflows")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/simple_client.py
+++ b/examples/simple_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import traceback
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -45,7 +46,20 @@ async def main():
                         "playground_url": playground_url,
                         "auth_token": auth_token
                     })
-                    print(f"Configuration result: {result}")
+
+                    # Parse the dictionary response
+                    if hasattr(result, 'content') and result.content and result.content[0].text:
+                        try:
+                            config_data = json.loads(result.content[0].text)
+                            if config_data.get("success"):
+                                print(f"✅ Configuration successful: {config_data.get('message')}")
+                                print(f"📋 Configured items: {list(config_data.get('configured_items', {}).keys())}")
+                            else:
+                                print(f"❌ Configuration failed: {config_data.get('error', 'Unknown error')}")
+                        except json.JSONDecodeError:
+                            print(f"Configuration result: {result}")
+                    else:
+                        print(f"Configuration result: {result}")
             
                 # Choose interaction mode
                 print("\nChoose interaction mode:")
@@ -53,7 +67,8 @@ async def main():
                 print("2. Thread management demo")
                 print("3. Thread cancellation demo")
                 print("4. Start thread without polling demo")
-                mode = input("Enter choice (1, 2, 3, or 4): ").strip()
+                print("5. Artifact retrieval demo")
+                mode = input("Enter choice (1, 2, 3, 4, or 5): ").strip()
 
                 if mode == "1":
                     await multi_turn_conversation(client)
@@ -63,6 +78,8 @@ async def main():
                     await thread_cancellation_demo(client)
                 elif mode == "4":
                     await start_thread_without_polling_demo(client)
+                elif mode == "5":
+                    await artifact_demo(client)
                 else:
                     print("Invalid choice. Using multi-turn conversation mode.")
                     await multi_turn_conversation(client)
@@ -101,20 +118,34 @@ async def multi_turn_conversation(client):
             result = await client.call_tool("start_thread", {"message": question})
             print(f"Result: {result}")
 
-            # Access result directly without extract_result_text
+            # Parse the dictionary response
             if hasattr(result, 'content') and result.content and result.content[0].text:
-                result_text = result.content[0].text
+                try:
+                    result_data = json.loads(result.content[0].text)
 
-                if "Thread ID:" in result_text:
-                    thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
-                    conversation_count += 1
-                    print(f"✅ Thread started with ID: {thread_id}")
+                    if result_data.get("success"):
+                        thread_id = result_data.get("thread_id")
+                        conversation_count += 1
+                        print(f"✅ Thread started with ID: {thread_id}")
 
-                    # Display the complete response (start_thread now waits for completion)
-                    print(f"\n📝 Response:")
-                    print(result_text)
-                else:
-                    print("❌ Failed to start thread")
+                        # Display the structured response
+                        print(f"\n📝 Answer:")
+                        print(result_data.get("answer", "No answer available"))
+
+                        # Show additional info if available
+                        if result_data.get("plans"):
+                            print(f"\n📋 Plans: {len(result_data['plans'])} found")
+                        if result_data.get("code_blocks"):
+                            print(f"\n� Code blocks: {len(result_data['code_blocks'])} found")
+                        if result_data.get("artifacts"):
+                            print(f"\n📎 Artifacts: {result_data['artifacts']}")
+
+                        print(f"\n📊 Interactions: {result_data.get('interactions_count', 0)}")
+                    else:
+                        print(f"❌ Failed to start thread: {result_data.get('error', 'Unknown error')}")
+                        continue
+                except json.JSONDecodeError:
+                    print("❌ Failed to parse response as JSON")
                     continue
             else:
                 print("❌ Failed to start thread")
@@ -129,7 +160,19 @@ async def multi_turn_conversation(client):
                 break
             elif question.lower() == 'status':
                 status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
-                print(f"📊 Thread status: {status_result}")
+
+                # Parse status response
+                if hasattr(status_result, 'content') and status_result.content and status_result.content[0].text:
+                    try:
+                        status_data = json.loads(status_result.content[0].text)
+                        print(f"📊 Thread Status:")
+                        print(f"   Status: {status_data.get('status', 'Unknown')}")
+                        print(f"   Interactions: {status_data.get('interactions_count', 0)}")
+                        print(f"   Message: {status_data.get('message', 'No message')}")
+                    except json.JSONDecodeError:
+                        print(f"📊 Thread status: {status_result}")
+                else:
+                    print(f"📊 Thread status: {status_result}")
                 continue
 
             print(f"\n💬 Continuing thread {thread_id}...")
@@ -138,8 +181,32 @@ async def multi_turn_conversation(client):
                 "message": question
             })
             conversation_count += 1
-            print(f"\n📝 Response:")
-            print(result)
+
+            # Parse continue_thread response
+            if hasattr(result, 'content') and result.content and result.content[0].text:
+                try:
+                    continue_data = json.loads(result.content[0].text)
+                    if continue_data.get("success"):
+                        print(f"\n📝 Answer:")
+                        print(continue_data.get("answer", "No answer available"))
+
+                        # Show additional info if available
+                        if continue_data.get("plans"):
+                            print(f"\n📋 Plans: {len(continue_data['plans'])} found")
+                        if continue_data.get("code_blocks"):
+                            print(f"\n� Code blocks: {len(continue_data['code_blocks'])} found")
+                        if continue_data.get("artifacts"):
+                            print(f"\n📎 Artifacts: {continue_data['artifacts']}")
+
+                        print(f"\n📊 Total interactions: {continue_data.get('interactions_count', 0)}")
+                    else:
+                        print(f"❌ Error continuing thread: {continue_data.get('error', 'Unknown error')}")
+                except json.JSONDecodeError:
+                    print(f"\n📝 Response:")
+                    print(result)
+            else:
+                print(f"\n�📝 Response:")
+                print(result)
 
     if thread_id:
         print(f"\n🏁 Conversation ended. Final thread ID: {thread_id}")
@@ -147,7 +214,19 @@ async def multi_turn_conversation(client):
 
         # Get final status
         final_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
-        print(f"📊 Final thread status: {final_status}")
+
+        # Parse final status response
+        if hasattr(final_status, 'content') and final_status.content and final_status.content[0].text:
+            try:
+                final_data = json.loads(final_status.content[0].text)
+                print(f"📊 Final Thread Status:")
+                print(f"   Status: {final_data.get('status', 'Unknown')}")
+                print(f"   Total Interactions: {final_data.get('interactions_count', 0)}")
+                print(f"   Message: {final_data.get('message', 'No message')}")
+            except json.JSONDecodeError:
+                print(f"📊 Final thread status: {final_status}")
+        else:
+            print(f"📊 Final thread status: {final_status}")
 
 async def thread_management_demo(client):
     """Demonstrate thread management capabilities using continue_thread."""
@@ -165,55 +244,100 @@ async def thread_management_demo(client):
     result = await client.call_tool("start_thread", {"message": initial_question})
     print(f"Start result: {result}")
 
-    # Access result directly without extract_result_text
+    # Parse the dictionary response
     if hasattr(result, 'content') and result.content and result.content[0].text:
-        result_text = result.content[0].text
+        try:
+            result_data = json.loads(result.content[0].text)
 
-        if "Thread ID:" in result_text:
-            thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
-            print(f"✅ Thread started with ID: {thread_id}")
+            if result_data.get("success"):
+                thread_id = result_data.get("thread_id")
+                print(f"✅ Thread started with ID: {thread_id}")
 
-            # Display the complete initial response (start_thread now waits for completion)
-            print(f"\n📝 Initial Response:")
-            print(result_text)
+                # Display the structured initial response
+                print(f"\n📝 Initial Answer:")
+                print(result_data.get("answer", "No answer available"))
 
-        # Continue with related questions using the same thread
-        follow_up_questions = [
+                # Show additional info if available
+                if result_data.get("plans"):
+                    print(f"\n📋 Plans: {len(result_data['plans'])} found")
+                if result_data.get("code_blocks"):
+                    print(f"\n💻 Code blocks: {len(result_data['code_blocks'])} found")
+                if result_data.get("artifacts"):
+                    print(f"\n� Artifacts: {result_data['artifacts']}")
+            else:
+                print(f"❌ Failed to start thread: {result_data.get('error', 'Unknown error')}")
+                return
+        except json.JSONDecodeError:
+            print("❌ Failed to parse response as JSON")
+            return
+    else:
+        print("❌ Failed to start thread")
+        return
+
+    # Continue with related questions using the same thread
+    follow_up_questions = [
             "Tell me more about the largest table you found",
             "Show me the schema of that table",
             "How many records are in that table?",
             "Can you show me a sample of data from it?"
         ]
 
-        print(f"\n🔄 Continuing thread with {len(follow_up_questions)} follow-up questions...")
+    print(f"\n🔄 Continuing thread with {len(follow_up_questions)} follow-up questions...")
 
-        for i, question in enumerate(follow_up_questions, 1):
-            print(f"\n--- Follow-up {i} ---")
-            print(f"Question: {question}")
+    for i, question in enumerate(follow_up_questions, 1):
+        print(f"\n--- Follow-up {i} ---")
+        print(f"Question: {question}")
 
-            # Check status before asking the follow-up question
-            print("📊 Checking thread status before continuing...")
-            pre_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+        # Check status before asking the follow-up question
+        print("📊 Checking thread status before continuing...")
+        pre_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+
+        # Parse pre-status response
+        if hasattr(pre_status, 'content') and pre_status.content and pre_status.content[0].text:
+            try:
+                pre_data = json.loads(pre_status.content[0].text)
+                print(f"Pre-continue status: {pre_data.get('status', 'Unknown')} ({pre_data.get('interactions_count', 0)} interactions)")
+            except json.JSONDecodeError:
+                print(f"Pre-continue status: {pre_status}")
+        else:
             print(f"Pre-continue status: {pre_status}")
 
-            # Use continue_thread to maintain context
-            continue_result = await client.call_tool("continue_thread", {
-                "thread_id": thread_id,
-                "message": question
-            })
+        # Use continue_thread to maintain context
+        continue_result = await client.call_tool("continue_thread", {
+            "thread_id": thread_id,
+            "message": question
+        })
+
+        # Parse continue result
+        if hasattr(continue_result, 'content') and continue_result.content and continue_result.content[0].text:
+            try:
+                continue_data = json.loads(continue_result.content[0].text)
+                if continue_data.get("success"):
+                    print(f"✅ Continue successful - Answer: {continue_data.get('answer', 'No answer')[:100]}...")
+                else:
+                    print(f"❌ Continue failed: {continue_data.get('error', 'Unknown error')}")
+            except json.JSONDecodeError:
+                print(f"Continue result: {continue_result}")
+        else:
             print(f"Continue result: {continue_result}")
 
-            # Check status after each continuation
-            status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+        # Check status after each continuation
+        status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+
+        # Parse post-status response
+        if hasattr(status_result, 'content') and status_result.content and status_result.content[0].text:
+            try:
+                post_data = json.loads(status_result.content[0].text)
+                print(f"📊 Post-continue status: {post_data.get('status', 'Unknown')} ({post_data.get('interactions_count', 0)} interactions)")
+            except json.JSONDecodeError:
+                print(f"📊 Post-continue status: {status_result}")
+        else:
             print(f"📊 Post-continue status: {status_result}")
 
-            # Small delay between questions
-            await asyncio.sleep(2)
+        # Small delay between questions
+        await asyncio.sleep(2)
 
-        print(f"\n🏁 Demo completed. Used continue_thread {len(follow_up_questions)} times on thread {thread_id[:8]}...")
-
-    else:
-        print("❌ Failed to start initial thread")
+    print(f"\n🏁 Demo completed. Used continue_thread {len(follow_up_questions)} times on thread {thread_id[:8]}...")
 
     print("\nKey benefits of continue_thread:")
     print("- Maintains conversation context across questions")
@@ -239,44 +363,96 @@ async def thread_cancellation_demo(client):
     result = await client.call_tool("start_thread_without_polling", {"message": complex_question})
     print(f"Start result: {result}")
 
-    # Access result directly without extract_result_text
+    # Parse the dictionary response
     if hasattr(result, 'content') and result.content and result.content[0].text:
-        result_text = result.content[0].text
+        try:
+            result_data = json.loads(result.content[0].text)
 
-        if "Thread ID:" in result_text:
-            thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
-            print(f"✅ Thread started with ID: {thread_id}")
+            if result_data.get("success"):
+                thread_id = result_data.get("thread_id")
+                print(f"✅ Thread started with ID: {thread_id}")
 
-            # Display the immediate response (should just be thread info)
-            print(f"\n📝 Immediate Response:")
-            print(result_text)
-
-        # Give the thread a moment to start processing
-        print("\n⏳ Waiting 3 seconds for processing to begin...")
-        await asyncio.sleep(3)
-
-        # Check status (should be processing)
-        print("\n📊 Checking thread status...")
-        status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
-        print(f"Status: {status_result}")
-
-        # Attempt to cancel while processing
-        print(f"\n🛑 Attempting to cancel thread {thread_id} while processing...")
-        cancel_result = await client.call_tool("cancel_thread", {"thread_id": thread_id})
-        print(f"Cancel result: {cancel_result}")
-
-        # Check status after cancellation
-        print("\n📊 Checking thread status after cancellation...")
-        final_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
-        print(f"Final status: {final_status}")
-
-        # Try to cancel again (should fail since it's no longer processing)
-        print(f"\n🛑 Attempting to cancel again (should fail)...")
-        second_cancel = await client.call_tool("cancel_thread", {"thread_id": thread_id})
-        print(f"Second cancel result: {second_cancel}")
-
+                # Display the immediate response (should just be thread info)
+                print(f"\n📝 Immediate Response:")
+                print(f"Thread ID: {thread_id}")
+                print(f"Interaction ID: {result_data.get('interaction_id')}")
+                print(f"Status: {result_data.get('status')}")
+                print(f"Message: {result_data.get('message')}")
+            else:
+                print(f"❌ Failed to start thread: {result_data.get('error', 'Unknown error')}")
+                return
+        except json.JSONDecodeError:
+            print("❌ Failed to parse response as JSON")
+            return
     else:
         print("❌ Failed to start thread")
+        return
+
+    # Give the thread a moment to start processing
+    print("\n⏳ Waiting 3 seconds for processing to begin...")
+    await asyncio.sleep(3)
+
+    # Check status (should be processing)
+    print("\n📊 Checking thread status...")
+    status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+
+    # Parse status response
+    if hasattr(status_result, 'content') and status_result.content and status_result.content[0].text:
+        try:
+            status_data = json.loads(status_result.content[0].text)
+            print(f"Status: {status_data.get('status', 'Unknown')} ({status_data.get('interactions_count', 0)} interactions)")
+        except json.JSONDecodeError:
+            print(f"Status: {status_result}")
+    else:
+        print(f"Status: {status_result}")
+
+    # Attempt to cancel while processing
+    print(f"\n🛑 Attempting to cancel thread {thread_id} while processing...")
+    cancel_result = await client.call_tool("cancel_thread", {"thread_id": thread_id})
+
+    # Parse cancel result
+    if hasattr(cancel_result, 'content') and cancel_result.content and cancel_result.content[0].text:
+        try:
+            cancel_data = json.loads(cancel_result.content[0].text)
+            if cancel_data.get("success"):
+                print(f"✅ Cancel successful: {cancel_data.get('message')}")
+            else:
+                print(f"❌ Cancel failed: {cancel_data.get('error', 'Unknown error')}")
+        except json.JSONDecodeError:
+            print(f"Cancel result: {cancel_result}")
+    else:
+        print(f"Cancel result: {cancel_result}")
+
+    # Check status after cancellation
+    print("\n📊 Checking thread status after cancellation...")
+    final_status = await client.call_tool("get_thread_status", {"thread_id": thread_id})
+
+    # Parse final status response
+    if hasattr(final_status, 'content') and final_status.content and final_status.content[0].text:
+        try:
+            final_data = json.loads(final_status.content[0].text)
+            print(f"Final status: {final_data.get('status', 'Unknown')} ({final_data.get('interactions_count', 0)} interactions)")
+        except json.JSONDecodeError:
+            print(f"Final status: {final_status}")
+    else:
+        print(f"Final status: {final_status}")
+
+    # Try to cancel again (should fail since it's no longer processing)
+    print(f"\n🛑 Attempting to cancel again (should fail)...")
+    second_cancel = await client.call_tool("cancel_thread", {"thread_id": thread_id})
+
+    # Parse second cancel result
+    if hasattr(second_cancel, 'content') and second_cancel.content and second_cancel.content[0].text:
+        try:
+            second_data = json.loads(second_cancel.content[0].text)
+            if second_data.get("success"):
+                print(f"✅ Second cancel successful: {second_data.get('message')}")
+            else:
+                print(f"❌ Second cancel failed (expected): {second_data.get('error', 'Unknown error')}")
+        except json.JSONDecodeError:
+            print(f"Second cancel result: {second_cancel}")
+    else:
+        print(f"Second cancel result: {second_cancel}")
 
     print(f"\n🏁 Cancellation demo completed.")
     print("\nKey points about thread cancellation:")
@@ -302,49 +478,83 @@ async def start_thread_without_polling_demo(client):
     result = await client.call_tool("start_thread_without_polling", {"message": question})
     print(f"Start result: {result}")
 
-    # Access result directly without extract_result_text
+    # Parse the dictionary response
     if hasattr(result, 'content') and result.content and result.content[0].text:
-        result_text = result.content[0].text
+        try:
+            result_data = json.loads(result.content[0].text)
 
-        if "Thread ID:" in result_text:
-            thread_id = result_text.split("Thread ID: ")[1].split("\n")[0].strip()
-            print(f"✅ Thread started with ID: {thread_id}")
+            if result_data.get("success"):
+                thread_id = result_data.get("thread_id")
+                print(f"✅ Thread started with ID: {thread_id}")
 
-            # Display the immediate response (should just be thread info)
-            print(f"\n📝 Immediate Response:")
-            print(result_text)
+                # Display the immediate response (should just be thread info)
+                print(f"\n📝 Immediate Response:")
+                print(f"Thread ID: {thread_id}")
+                print(f"Interaction ID: {result_data.get('interaction_id')}")
+                print(f"Status: {result_data.get('status')}")
+                print(f"Message: {result_data.get('message')}")
+            else:
+                print(f"❌ Failed to start thread: {result_data.get('error', 'Unknown error')}")
+                return
+        except json.JSONDecodeError:
+            print("❌ Failed to parse response as JSON")
+            return
+    else:
+        print("❌ Failed to start thread")
+        return
 
-        # Now manually check status multiple times
-        print(f"\n📊 Manually checking thread status...")
+    # Now manually check status multiple times
+    print(f"\n📊 Manually checking thread status...")
 
-        for i in range(5):  # Check up to 5 times
-            print(f"\n--- Status Check {i+1} ---")
-            status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
-            print(f"Status: {status_result}")
+    for i in range(5):  # Check up to 5 times
+        print(f"\n--- Status Check {i+1} ---")
+        status_result = await client.call_tool("get_thread_status", {"thread_id": thread_id})
 
-            # Check if the status indicates completion
-            if hasattr(status_result, 'content') and status_result.content and status_result.content[0].text:
-                status_text = status_result.content[0].text
-                if '"status": "complete"' in status_text or 'status: complete' in status_text.lower():
+        # Parse status response
+        if hasattr(status_result, 'content') and status_result.content and status_result.content[0].text:
+            try:
+                status_data = json.loads(status_result.content[0].text)
+                status = status_data.get('status', 'Unknown')
+                interactions = status_data.get('interactions_count', 0)
+                print(f"Status: {status} ({interactions} interactions)")
+
+                if status == "complete":
                     print("✅ Thread completed!")
                     break
-            else:
+                else:
+                    print("⏳ Thread still processing, waiting 3 seconds...")
+                    await asyncio.sleep(3)
+            except json.JSONDecodeError:
+                print(f"Status: {status_result}")
                 print("⏳ Thread still processing, waiting 3 seconds...")
                 await asyncio.sleep(3)
         else:
-            print("⏰ Stopped checking after 5 attempts")
-
-        # Try to continue the thread
-        print(f"\n💬 Continuing thread with follow-up question...")
-        follow_up = "Can you show me the schema of the largest table?"
-        continue_result = await client.call_tool("continue_thread", {
-            "thread_id": thread_id,
-            "message": follow_up
-        })
-        print(f"Continue result: {continue_result}")
-
+            print(f"Status: {status_result}")
+            print("⏳ Thread still processing, waiting 3 seconds...")
+            await asyncio.sleep(3)
     else:
-        print("❌ Failed to start thread")
+        print("⏰ Stopped checking after 5 attempts")
+
+    # Try to continue the thread
+    print(f"\n💬 Continuing thread with follow-up question...")
+    follow_up = "Can you show me the schema of the largest table?"
+    continue_result = await client.call_tool("continue_thread", {
+        "thread_id": thread_id,
+        "message": follow_up
+    })
+
+    # Parse continue result
+    if hasattr(continue_result, 'content') and continue_result.content and continue_result.content[0].text:
+        try:
+            continue_data = json.loads(continue_result.content[0].text)
+            if continue_data.get("success"):
+                print(f"✅ Continue successful - Answer: {continue_data.get('answer', 'No answer')[:100]}...")
+            else:
+                print(f"❌ Continue failed: {continue_data.get('error', 'Unknown error')}")
+        except json.JSONDecodeError:
+            print(f"Continue result: {continue_result}")
+    else:
+        print(f"Continue result: {continue_result}")
 
     print(f"\n🏁 Start without polling demo completed.")
     print("\nKey points about starting without polling:")
@@ -352,6 +562,103 @@ async def start_thread_without_polling_demo(client):
     print("- Thread processing happens asynchronously")
     print("- Use get_thread_status to check progress")
     print("- Can continue threads even while they're processing")
+
+async def artifact_demo(client):
+    """Demonstrate artifact retrieval functionality."""
+    print("\n" + "="*60)
+    print("🎯 ARTIFACT RETRIEVAL DEMO")
+    print("="*60)
+    print("This demo shows how to retrieve artifacts created by threads.")
+    print("We'll start a thread that creates files and then retrieve them.")
+    print("="*60)
+
+    # Start a thread that should create artifacts
+    artifact_question = "Create a CSV file with sample sales data for the top 5 products. Include columns for product name, sales amount, and region."
+
+    print(f"\n🚀 Starting thread to create artifacts...")
+    print(f"Question: {artifact_question}")
+
+    result = await client.call_tool("start_thread", {"message": artifact_question})
+
+    # Parse the dictionary response
+    if hasattr(result, 'content') and result.content and result.content[0].text:
+        try:
+            result_data = json.loads(result.content[0].text)
+
+            if result_data.get("success"):
+                thread_id = result_data.get("thread_id")
+                artifacts = result_data.get("artifacts", [])
+
+                print(f"✅ Thread completed with ID: {thread_id}")
+                print(f"📎 Artifacts created: {len(artifacts)}")
+
+                if artifacts:
+                    # Test get_artifact with each artifact
+                    for i, artifact in enumerate(artifacts, 1):
+                        artifact_id = artifact.get('id') if isinstance(artifact, dict) else artifact
+                        print(f"\n--- Artifact {i}: {artifact_id} ---")
+
+                        artifact_result = await client.call_tool("get_artifact", {
+                            "thread_id": thread_id,
+                            "artifact_id": artifact_id
+                        })
+
+                        # Parse artifact result
+                        if hasattr(artifact_result, 'content') and artifact_result.content and artifact_result.content[0].text:
+                            try:
+                                artifact_data = json.loads(artifact_result.content[0].text)
+                                if artifact_data.get("success"):
+                                    print(f"✅ Artifact retrieved successfully!")
+                                    print(f"   Content Type: {artifact_data.get('content_type')}")
+                                    print(f"   Size: {artifact_data.get('size')} bytes")
+
+                                    # Show preview of data
+                                    data = artifact_data.get("data", "")
+                                    if isinstance(data, str):
+                                        preview = data[:200] + "..." if len(data) > 200 else data
+                                        print(f"   Data preview:\n{preview}")
+                                    else:
+                                        print(f"   Data type: {type(data)}")
+                                        print(f"   Data preview: {str(data)[:100]}...")
+                                else:
+                                    print(f"❌ Failed to get artifact: {artifact_data.get('error')}")
+                            except json.JSONDecodeError:
+                                print(f"❌ Failed to parse artifact response")
+                        else:
+                            print(f"❌ No response from get_artifact")
+                else:
+                    print("ℹ️ No artifacts were created in this thread")
+
+                    # Test with a non-existent artifact to show error handling
+                    print(f"\n🔧 Testing error handling with non-existent artifact...")
+                    error_result = await client.call_tool("get_artifact", {
+                        "thread_id": thread_id,
+                        "artifact_id": "non-existent-artifact-id"
+                    })
+
+                    if hasattr(error_result, 'content') and error_result.content and error_result.content[0].text:
+                        try:
+                            error_data = json.loads(error_result.content[0].text)
+                            print(f"Expected error: {error_data.get('error')}")
+                        except json.JSONDecodeError:
+                            print(f"Error result: {error_result}")
+            else:
+                print(f"❌ Failed to start thread: {result_data.get('error', 'Unknown error')}")
+                return
+        except json.JSONDecodeError:
+            print("❌ Failed to parse response as JSON")
+            return
+    else:
+        print("❌ Failed to start thread")
+        return
+
+    print(f"\n🏁 Artifact demo completed.")
+    print("\nKey points about artifact retrieval:")
+    print("- Use get_artifact to retrieve files created by threads")
+    print("- Artifacts have IDs that can be found in thread responses")
+    print("- Supports various content types (CSV, JSON, text, etc.)")
+    print("- Returns content type, size, and actual data")
+    print("- Handles errors gracefully for non-existent artifacts")
     print("- Useful for non-blocking workflows")
 
 if __name__ == "__main__":

--- a/examples/simple_client.py
+++ b/examples/simple_client.py
@@ -35,11 +35,13 @@ async def main():
                 setup_config = input("\nDo you want to set up the server configuration? (y/n): ")
                 if setup_config.lower() == 'y':
                     api_key = input("Enter your PromptQL API key: ")
-                    ddn_url = input("Enter your DDN URL: ")
-                
+                    playground_url = input("Enter your PromptQL playground URL: ")
+                    auth_token = input("Enter your DDN Auth Token: ")
+
                     result = await client.call_tool("setup_config", {
                         "api_key": api_key,
-                        "ddn_url": ddn_url
+                        "playground_url": playground_url,
+                        "auth_token": auth_token
                     })
                     print(f"Configuration result: {result}")
             

--- a/promptql_mcp_server/__main__.py
+++ b/promptql_mcp_server/__main__.py
@@ -4,7 +4,6 @@ import sys
 import os
 import argparse
 import logging
-import time
 from promptql_mcp_server.server import mcp, config
 
 # Configure logging
@@ -28,16 +27,18 @@ def main():
     # Setup command
     setup_parser = subparsers.add_parser("setup", help="Configure the server")
     setup_parser.add_argument("--api-key", required=True, help="PromptQL API key")
-    setup_parser.add_argument("--ddn-url", required=True, help="DDN URL")
-    
+    setup_parser.add_argument("--playground-url", required=True, help="PromptQL playground URL")
+    setup_parser.add_argument("--auth-token", required=True, help="DDN Auth Token")
+
     # Run command (default)
     run_parser = subparsers.add_parser("run", help="Run the server")
-    
+
     args = parser.parse_args()
-    
+
     if args.command == "setup":
         config.set("api_key", args.api_key)
-        config.set("ddn_url", args.ddn_url)
+        config.set("playground_url", args.playground_url)
+        config.set("auth_token", args.auth_token)
         logger.info("Configuration saved successfully.")
         return 0
     
@@ -47,20 +48,23 @@ def main():
     
     # Check if configuration is set
     api_key = config.get("api_key")
-    ddn_url = config.get("ddn_url")
-    
-    if not api_key or not ddn_url:
-        logger.warning("WARNING: PromptQL API key or DDN URL not configured.")
-        logger.warning("You can configure them by running:")
-        logger.warning("  python -m promptql_mcp_server setup --api-key YOUR_API_KEY --ddn-url YOUR_DDN_URL")
+    playground_url = config.get("playground_url")
+    auth_token = config.get("auth_token")
+
+    if not api_key or not playground_url or not auth_token:
+        logger.warning("WARNING: PromptQL configuration incomplete.")
+        logger.warning("You can configure by running:")
+        logger.warning("  python -m promptql_mcp_server setup --api-key YOUR_API_KEY --playground-url YOUR_PLAYGROUND_URL --auth-token YOUR_AUTH_TOKEN")
         logger.warning("Or by setting environment variables:")
-        logger.warning("  PROMPTQL_API_KEY and PROMPTQL_DDN_URL")
+        logger.warning("  PROMPTQL_API_KEY, PROMPTQL_PLAYGROUND_URL, and PROMPTQL_AUTH_TOKEN")
         logger.warning("Continuing with unconfigured server...")
     else:
-        # Show partial key for debugging
+        # Show partial credentials for debugging
         masked_key = f"{api_key[:8]}...{api_key[-4:]}" if api_key else "None"
+        masked_token = f"{auth_token[:8]}...{auth_token[-4:]}" if len(auth_token) > 12 else auth_token[:4] + "..."
         logger.info(f"Using API Key: {masked_key}")
-        logger.info(f"Using DDN URL: {ddn_url}")
+        logger.info(f"Using Playground URL: {playground_url}")
+        logger.info(f"Using Auth Token: {masked_token}")
     
     # Run the MCP server
     logger.info("STARTING MCP SERVER - READY FOR CONNECTIONS")

--- a/promptql_mcp_server/__main__.py
+++ b/promptql_mcp_server/__main__.py
@@ -29,6 +29,8 @@ def main():
     setup_parser.add_argument("--api-key", required=True, help="PromptQL API key")
     setup_parser.add_argument("--playground-url", required=True, help="PromptQL playground URL")
     setup_parser.add_argument("--auth-token", required=True, help="DDN Auth Token")
+    setup_parser.add_argument("--auth-mode", default="public", choices=["public", "private"],
+                             help="Authentication mode: 'public' for Auth-Token or 'private' for x-hasura-ddn-token (default: public)")
 
     # Run command (default)
     run_parser = subparsers.add_parser("run", help="Run the server")
@@ -39,7 +41,8 @@ def main():
         config.set("api_key", args.api_key)
         config.set("playground_url", args.playground_url)
         config.set("auth_token", args.auth_token)
-        logger.info("Configuration saved successfully.")
+        config.set("auth_mode", args.auth_mode)
+        logger.info(f"Configuration saved successfully with auth_mode: {args.auth_mode}")
         return 0
     
     # Default to running the server
@@ -50,13 +53,14 @@ def main():
     api_key = config.get("api_key")
     playground_url = config.get("playground_url")
     auth_token = config.get("auth_token")
+    auth_mode = config.get_auth_mode()
 
     if not api_key or not playground_url or not auth_token:
         logger.warning("WARNING: PromptQL configuration incomplete.")
         logger.warning("You can configure by running:")
-        logger.warning("  python -m promptql_mcp_server setup --api-key YOUR_API_KEY --playground-url YOUR_PLAYGROUND_URL --auth-token YOUR_AUTH_TOKEN")
+        logger.warning("  python -m promptql_mcp_server setup --api-key YOUR_API_KEY --playground-url YOUR_PLAYGROUND_URL --auth-token YOUR_AUTH_TOKEN --auth-mode public")
         logger.warning("Or by setting environment variables:")
-        logger.warning("  PROMPTQL_API_KEY, PROMPTQL_PLAYGROUND_URL, and PROMPTQL_AUTH_TOKEN")
+        logger.warning("  PROMPTQL_API_KEY, PROMPTQL_PLAYGROUND_URL, PROMPTQL_AUTH_TOKEN, and PROMPTQL_AUTH_MODE")
         logger.warning("Continuing with unconfigured server...")
     else:
         # Show partial credentials for debugging
@@ -65,6 +69,7 @@ def main():
         logger.info(f"Using API Key: {masked_key}")
         logger.info(f"Using Playground URL: {playground_url}")
         logger.info(f"Using Auth Token: {masked_token}")
+        logger.info(f"Using Auth Mode: {auth_mode}")
     
     # Run the MCP server
     logger.info("STARTING MCP SERVER - READY FOR CONNECTIONS")

--- a/promptql_mcp_server/api/promptql_client.py
+++ b/promptql_mcp_server/api/promptql_client.py
@@ -4,7 +4,8 @@ import requests
 import json
 import logging
 import sys
-from typing import Dict, List, Any, Optional, Tuple
+import time
+from typing import Dict
 
 # Configure logging to output to stderr
 logging.basicConfig(
@@ -16,111 +17,168 @@ logging.basicConfig(
 logger = logging.getLogger("promptql_client")
 
 class PromptQLClient:
-    """Client for interacting with the PromptQL Natural Language API."""
-    
-    def __init__(self, api_key: str, ddn_url: str, timezone: str = "America/Los_Angeles"):
+    """Client for interacting with the PromptQL Async Threads API."""
+
+    def __init__(self, api_key: str, playground_url: str, auth_token: str, timezone: str = "America/Los_Angeles"):
         """Initialize the PromptQL API client."""
         self.api_key = api_key
-        self.ddn_url = ddn_url
+        self.playground_url = playground_url.rstrip('/')  # Remove trailing slash if present
+        self.auth_token = auth_token
         self.timezone = timezone
-        self.base_url = "https://api.promptql.pro.hasura.io"
         
-    def query(self, 
-              message: str, 
-              artifacts: List[Dict] = None, 
-              system_instructions: str = None, 
-              llm_provider: str = "hasura", 
-              stream: bool = False) -> Dict:
-        """Send a query to the PromptQL API."""
+    def query(self, message: str, system_instructions: str = None) -> Dict:
+        """Send a query to the PromptQL Async Threads API."""
         logger.info("="*80)
         logger.info(f"SENDING QUERY TO PROMPTQL: '{message}'")
         logger.info("="*80)
-        
+
         # Debug API key - show first 8 chars and last 4 for verification
         api_key_debug = f"{self.api_key[:8]}...{self.api_key[-4:]}" if self.api_key else "None"
         logger.info(f"Using API Key: {api_key_debug}")
-        logger.info(f"Using DDN URL: {self.ddn_url}")
-        
+        logger.info(f"Using Playground URL: {self.playground_url}")
+        logger.info(f"Using Auth Token: {self.auth_token[:8]}...{self.auth_token[-4:] if len(self.auth_token) > 8 else ''}")
+
+        # Step 1: Start a new thread
+        thread_id = self._start_thread(message, system_instructions)
+        if isinstance(thread_id, dict) and "error" in thread_id:
+            return thread_id
+
+        # Step 2: Poll for thread completion
+        return self._poll_thread_completion(thread_id)
+
+    def _start_thread(self, message: str, system_instructions: str = None) -> str:
+        """Start a new thread with the given message."""
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.api_key}"
+            "Authorization": f"api-key {self.api_key}"
         }
-        
-        # Configure LLM provider
-        llm_config = {"provider": llm_provider}
-        
-        # Build request body
+
+        # Build request body for new async API
         request_body = {
-            "version": "v1",
-            "llm": llm_config,
-            "ddn": {
-                "url": self.ddn_url,
-                "headers": {}
+            "user_message": message,
+            "ddn_headers": {
+                "Auth-Token": self.auth_token
             },
-            "artifacts": artifacts or [],
-            "timezone": self.timezone,
-            "interactions": [
-                {
-                    "user_message": {
-                        "text": message
-                    },
-                    "assistant_actions": []
-                }
-            ],
-            "stream": stream
+            "timezone": self.timezone
         }
-        
+
+        # Add system instructions if provided
         if system_instructions:
             request_body["system_instructions"] = system_instructions
-        
+
         # Print the request payload in a readable format
         logger.info("REQUEST PAYLOAD:")
         logger.info(json.dumps(request_body, indent=2))
-        
-        # Send request
-        logger.info("SENDING REQUEST TO PROMPTQL API...")
-        
+
+        # Send request to start thread
+        logger.info("STARTING NEW THREAD...")
+
         try:
             response = requests.post(
-                f"{self.base_url}/query",
+                f"{self.playground_url}/threads/v2/start",
                 headers=headers,
                 json=request_body,
-                stream=stream,
-                timeout=60  # Longer timeout for PromptQL to process
+                timeout=30
             )
         except Exception as e:
             logger.error(f"CONNECTION ERROR: {str(e)}")
             return {"error": f"Connection error: {str(e)}"}
-        
+
         if response.status_code != 200:
             logger.error(f"ERROR: HTTP {response.status_code}")
             logger.error(f"Response: {response.text}")
             return {"error": f"API error: {response.status_code}", "details": response.text}
-        
-        if not stream:
+
+        try:
+            result = response.json()
+            thread_id = result.get("thread_id")
+            if not thread_id:
+                logger.error("No thread_id in response")
+                return {"error": "No thread_id received from API"}
+
+            logger.info(f"THREAD STARTED: {thread_id}")
+            return thread_id
+        except json.JSONDecodeError:
+            logger.error("ERROR: Failed to parse JSON response")
+            logger.error(f"Raw response: {response.text[:500]}...")
+            return {"error": "Failed to parse thread start response"}
+
+    def _poll_thread_completion(self, thread_id: str, max_wait_time: int = 120, poll_interval: int = 2) -> Dict:
+        """Poll for thread completion and return the final result."""
+        logger.info(f"POLLING THREAD {thread_id} FOR COMPLETION...")
+
+        start_time = time.time()
+
+        while time.time() - start_time < max_wait_time:
             try:
-                result = response.json()
-                logger.info("RECEIVED RESPONSE FROM PROMPTQL API")
-                
-                # Log only the beginning of large responses
-                response_text = json.dumps(result, indent=2)
-                if len(response_text) > 1000:
-                    logger.info(f"RESPONSE PAYLOAD (truncated): {response_text[:1000]}...")
-                else:
-                    logger.info(f"RESPONSE PAYLOAD: {response_text}")
-                
-                # Check for artifacts
-                if "modified_artifacts" in result:
-                    artifacts = result["modified_artifacts"]
-                    logger.info(f"FOUND {len(artifacts)} ARTIFACTS IN RESPONSE")
-                    for idx, artifact in enumerate(artifacts):
-                        logger.info(f"  Artifact {idx+1}: {artifact.get('title', 'Unnamed')} ({artifact.get('artifact_type', 'unknown')})")
-                
-                return result
-            except json.JSONDecodeError:
-                logger.error("ERROR: Failed to parse JSON response")
-                logger.error(f"Raw response: {response.text[:500]}...")
-                return {"error": "Failed to parse PromptQL response"}
-        else:
-            # Return the response object for streaming
-            return response
+                # Get thread state
+                response = requests.get(
+                    f"{self.playground_url}/threads/v2/{thread_id}",
+                    headers={"Authorization": f"api-key {self.api_key}"},
+                    timeout=30
+                )
+
+                if response.status_code != 200:
+                    logger.error(f"ERROR polling thread: HTTP {response.status_code}")
+                    logger.error(f"Response: {response.text}")
+                    return {"error": f"Polling error: {response.status_code}", "details": response.text}
+
+                # Parse the response - it might be server-sent events format
+                thread_data = self._parse_thread_response(response.text)
+
+                if thread_data and self._is_thread_complete(thread_data):
+                    logger.info("THREAD COMPLETED")
+                    return thread_data
+
+                logger.info(f"Thread still processing, waiting {poll_interval}s...")
+                time.sleep(poll_interval)
+
+            except Exception as e:
+                logger.error(f"ERROR polling thread: {str(e)}")
+                return {"error": f"Polling error: {str(e)}"}
+
+        logger.error(f"TIMEOUT: Thread did not complete within {max_wait_time} seconds")
+        return {"error": f"Thread processing timeout after {max_wait_time} seconds"}
+
+    def _parse_thread_response(self, response_text: str) -> Dict:
+        """Parse the thread response, handling both JSON and server-sent events format."""
+        try:
+            # Try parsing as JSON first
+            return json.loads(response_text)
+        except json.JSONDecodeError:
+            # Handle server-sent events format
+            lines = response_text.strip().split('\n')
+            thread_state = None
+
+            for line in lines:
+                if line.startswith('data: '):
+                    try:
+                        event_data = json.loads(line[6:])  # Remove 'data: ' prefix
+                        if event_data.get("type") == "current_thread_state":
+                            thread_state = event_data.get("thread_state", {})
+                    except json.JSONDecodeError:
+                        continue
+
+            return thread_state or {}
+
+    def _is_thread_complete(self, thread_data: Dict) -> bool:
+        """Check if the thread processing is complete."""
+        # Look for the latest interaction and check if it's complete
+        interactions = thread_data.get("interactions", [])
+        if not interactions:
+            return False
+
+        latest_interaction = interactions[-1]
+        assistant_actions = latest_interaction.get("assistant_actions", [])
+
+        # If there are assistant actions, check if the last one is complete
+        if assistant_actions:
+            last_action = assistant_actions[-1]
+            # Check for completion indicators
+            return (
+                last_action.get("status") == "complete" or
+                last_action.get("message") is not None or
+                "llm_call_end_timestamp" in last_action
+            )
+
+        return False

--- a/promptql_mcp_server/config.py
+++ b/promptql_mcp_server/config.py
@@ -40,10 +40,16 @@ class ConfigManager:
         
         # If no file, try environment variables
         config = {}
-        for key in ["PROMPTQL_API_KEY", "PROMPTQL_DDN_URL"]:
-            if os.environ.get(key):
-                config[key.lower()] = os.environ.get(key)
-                logger.info(f"Using {key} from environment variables")
+        env_mappings = {
+            "PROMPTQL_API_KEY": "api_key",
+            "PROMPTQL_PLAYGROUND_URL": "playground_url",
+            "PROMPTQL_AUTH_TOKEN": "auth_token"
+        }
+
+        for env_key, config_key in env_mappings.items():
+            if os.environ.get(env_key):
+                config[config_key] = os.environ.get(env_key)
+                logger.info(f"Using {env_key} from environment variables")
         
         # If we got config from env vars, save it to file for persistence
         if config:
@@ -91,4 +97,6 @@ class ConfigManager:
     
     def is_configured(self) -> bool:
         """Check if the essential configuration is present."""
-        return bool(self.get("api_key")) and bool(self.get("ddn_url"))
+        return (bool(self.get("api_key")) and
+                bool(self.get("playground_url")) and
+                bool(self.get("auth_token")))

--- a/promptql_mcp_server/config.py
+++ b/promptql_mcp_server/config.py
@@ -43,7 +43,8 @@ class ConfigManager:
         env_mappings = {
             "PROMPTQL_API_KEY": "api_key",
             "PROMPTQL_PLAYGROUND_URL": "playground_url",
-            "PROMPTQL_AUTH_TOKEN": "auth_token"
+            "PROMPTQL_AUTH_TOKEN": "auth_token",
+            "PROMPTQL_AUTH_MODE": "auth_mode"
         }
 
         for env_key, config_key in env_mappings.items():
@@ -100,3 +101,7 @@ class ConfigManager:
         return (bool(self.get("api_key")) and
                 bool(self.get("playground_url")) and
                 bool(self.get("auth_token")))
+
+    def get_auth_mode(self) -> str:
+        """Get the authentication mode, defaulting to 'public' if not set."""
+        return self.get("auth_mode", "public")

--- a/promptql_mcp_server/server.py
+++ b/promptql_mcp_server/server.py
@@ -29,113 +29,7 @@ def _get_promptql_client() -> PromptQLClient:
 
     return PromptQLClient(api_key=api_key, playground_url=playground_url, auth_token=auth_token)
 
-@mcp.tool(name="ask_question")
-async def ask_question(question: str, system_instructions: Optional[str] = None) -> str:
-    """
-    Ask a natural language question to PromptQL.
 
-    Args:
-        question: The natural language query to ask
-        system_instructions: Optional system instructions for the LLM
-
-    Returns:
-        Answer from PromptQL
-    """
-    logger.info("="*80)
-    logger.info(f"TOOL CALL: ask_question")
-    logger.info(f"Question: '{question}'")
-    if system_instructions:
-        logger.info(f"System Instructions: '{system_instructions}'")
-    logger.info("="*80)
-    
-    try:
-        client = _get_promptql_client()
-        
-        response = client.query(
-            message=question,
-            system_instructions=system_instructions
-        )
-
-        if "error" in response:
-            error_message = f"Error: {response['error']}\n{response.get('details', '')}"
-            logger.error(f"ERROR RESPONSE: {error_message}")
-            return error_message
-
-        logger.info("PROCESSING PROMPTQL RESPONSE...")
-
-        # Extract the answer from the new thread response format
-        answer_text = "No answer received from PromptQL."
-
-        # Look for interactions in the thread state
-        interactions = response.get("interactions", [])
-        if interactions:
-            # Get the latest interaction
-            latest_interaction = interactions[-1]
-            assistant_actions = latest_interaction.get("assistant_actions", [])
-
-            if assistant_actions:
-                # Get the last assistant action with a message (most likely the final response)
-                for action in reversed(assistant_actions):
-                    if action.get("message"):
-                        answer_text = action.get("message", "")
-                        break
-
-                # Add plan and code from actions if available
-                for action in assistant_actions:
-                    # Add plan if available
-                    plan = action.get("plan")
-                    if plan and "**Execution Plan:**" not in answer_text:
-                        logger.info("EXECUTION PLAN FOUND")
-                        answer_text += f"\n\n**Execution Plan:**\n{plan}"
-
-                    # Add code if available
-                    code = action.get("code")
-                    if code and "**Executed Code:**" not in answer_text:
-                        logger.info("EXECUTED CODE FOUND")
-                        answer_text += f"\n\n**Executed Code:**\n{code}"
-
-                    # Add code output if available
-                    code_output = action.get("code_output")
-                    if code_output and "**Code Output:**" not in answer_text:
-                        logger.info("CODE OUTPUT FOUND")
-                        answer_text += f"\n\n**Code Output:**\n{code_output}"
-        
-        # Process artifacts if available in the new format
-        # In the new API, artifacts are referenced by identifier in the thread state
-        # We would need to make separate requests to fetch artifact data
-        # For now, let's look for artifact identifiers in the response
-        artifacts_found = []
-
-        # Look for artifact identifiers in assistant actions
-        if interactions:
-            for interaction in interactions:
-                assistant_actions = interaction.get("assistant_actions", [])
-                for action in assistant_actions:
-                    # Look for artifact references in the action
-                    artifact_identifiers = action.get("artifact_identifiers", [])
-                    if artifact_identifiers:
-                        artifacts_found.extend(artifact_identifiers)
-
-        if artifacts_found:
-            logger.info(f"ARTIFACT IDENTIFIERS FOUND: {len(artifacts_found)}")
-            answer_text += f"\n\n**Artifacts Generated:** {', '.join(artifacts_found)}"
-            answer_text += "\n\n*Note: Artifact data fetching will be implemented in a future update.*"
-        
-        logger.info("FINAL ANSWER PREPARED")
-        # Log only the beginning of the answer if it's very long
-        if len(answer_text) > 1000:
-            logger.info(f"ANSWER (truncated): {answer_text[:1000]}...")
-        else:
-            logger.info(f"ANSWER: {answer_text}")
-        
-        return answer_text
-        
-    except Exception as e:
-        import traceback
-        error_trace = traceback.format_exc()
-        logger.error(f"EXCEPTION IN TOOL: {str(e)}")
-        logger.error(error_trace)
-        return f"An error occurred while processing your question: {str(e)}"
 
 @mcp.tool(name="setup_config")
 def setup_config(api_key: str, playground_url: str, auth_token: str) -> str:
@@ -144,7 +38,7 @@ def setup_config(api_key: str, playground_url: str, auth_token: str) -> str:
 
     Args:
         api_key: PromptQL API key
-        playground_url: PromptQL playground URL (e.g., https://promptql.cisco-supplychain-hasura.private-ddn.hasura.app/playground)
+        playground_url: PromptQL playground URL (e.g., https://promptql.<dataplane-name>.private-ddn.hasura.app/playground)
         auth_token: DDN Auth Token for accessing your data
 
     Returns:
@@ -202,6 +96,345 @@ def check_config() -> str:
         status = f"PromptQL is not fully configured. Missing: {', '.join(missing)}"
         logger.info(f"CONFIGURATION CHECK: Missing {', '.join(missing)}")
         return status
+
+@mcp.tool(name="start_thread")
+async def start_thread(message: str, system_instructions: Optional[str] = None) -> str:
+    """
+    Start a new PromptQL thread with a message and poll for completion.
+
+    Args:
+        message: The initial message to start the thread with
+        system_instructions: Optional system instructions for the LLM
+
+    Returns:
+        Complete response from PromptQL including thread_id, interaction_id, and answer
+    """
+    logger.info("="*80)
+    logger.info(f"TOOL CALL: start_thread")
+    logger.info(f"Message: '{message}'")
+    logger.info("="*80)
+
+    try:
+        client = _get_promptql_client()
+
+        result = client.start_thread(
+            message=message,
+            system_instructions=system_instructions
+        )
+
+        if "error" in result:
+            error_message = f"Error: {result['error']}\n{result.get('details', '')}"
+            logger.error(f"ERROR RESPONSE: {error_message}")
+            return error_message
+
+        # Extract thread_id and interaction_id from the result
+        thread_id = result.get("thread_id")
+        interaction_id = result.get("interaction_id")
+
+        if not thread_id:
+            logger.error("No thread_id in response")
+            return "Error: No thread_id received from PromptQL"
+
+        logger.info(f"THREAD COMPLETED: {thread_id}")
+
+        # Extract the answer from the thread response format
+        answer_text = "No answer received from PromptQL."
+
+        # Look for interactions in the thread state
+        interactions = result.get("interactions", [])
+        if interactions:
+            # Get the latest interaction
+            latest_interaction = interactions[-1]
+            assistant_actions = latest_interaction.get("assistant_actions", [])
+
+            if assistant_actions:
+                # Get the last assistant action with a message (most likely the final response)
+                for action in reversed(assistant_actions):
+                    if action.get("message"):
+                        answer_text = action.get("message", "")
+                        break
+
+                # Add plan and code from actions if available
+                for action in assistant_actions:
+                    # Add plan if available
+                    plan = action.get("plan")
+                    if plan and "**Execution Plan:**" not in answer_text:
+                        logger.info("EXECUTION PLAN FOUND")
+                        answer_text += f"\n\n**Execution Plan:**\n{plan}"
+
+                    # Add code if available
+                    code = action.get("code")
+                    if code and "**Executed Code:**" not in answer_text:
+                        logger.info("EXECUTED CODE FOUND")
+                        answer_text += f"\n\n**Executed Code:**\n{code}"
+
+                    # Add code output if available
+                    code_output = action.get("code_output")
+                    if code_output and "**Code Output:**" not in answer_text:
+                        logger.info("CODE OUTPUT FOUND")
+                        answer_text += f"\n\n**Code Output:**\n{code_output}"
+
+        # Process artifacts if available
+        artifacts_found = []
+        if interactions:
+            for interaction in interactions:
+                assistant_actions = interaction.get("assistant_actions", [])
+                for action in assistant_actions:
+                    # Look for artifact references in the action
+                    artifact_identifiers = action.get("artifact_identifiers", [])
+                    if artifact_identifiers:
+                        artifacts_found.extend(artifact_identifiers)
+
+        if artifacts_found:
+            logger.info(f"ARTIFACT IDENTIFIERS FOUND: {len(artifacts_found)}")
+            answer_text += f"\n\n**Artifacts Generated:** {', '.join(artifacts_found)}"
+            answer_text += "\n\n*Note: Artifact data fetching will be implemented in a future update.*"
+
+        # Format the final response with thread info and answer
+        response_text = f"Thread ID: {thread_id}"
+        if interaction_id:
+            response_text += f"\nInteraction ID: {interaction_id}"
+        response_text += f"\n\n{answer_text}"
+
+        logger.info("FINAL RESPONSE PREPARED")
+        return response_text
+
+    except Exception as e:
+        import traceback
+        error_trace = traceback.format_exc()
+        logger.error(f"UNEXPECTED ERROR: {str(e)}")
+        logger.error(error_trace)
+        return f"Unexpected error: {str(e)}"
+
+@mcp.tool(name="start_thread_without_polling")
+async def start_thread_without_polling(message: str, system_instructions: Optional[str] = None) -> str:
+    """
+    Start a new PromptQL thread with a message without waiting for completion.
+
+    Args:
+        message: The initial message to start the thread with
+        system_instructions: Optional system instructions for the LLM
+
+    Returns:
+        Thread ID and interaction ID for the started thread
+    """
+    logger.info("="*80)
+    logger.info(f"TOOL CALL: start_thread_without_polling")
+    logger.info(f"Message: '{message}'")
+    logger.info("="*80)
+
+    try:
+        client = _get_promptql_client()
+
+        result = client.start_thread_without_polling(
+            message=message,
+            system_instructions=system_instructions
+        )
+
+        if "error" in result:
+            error_message = f"Error: {result['error']}\n{result.get('details', '')}"
+            logger.error(f"ERROR RESPONSE: {error_message}")
+            return error_message
+
+        # Extract thread_id and interaction_id from the result
+        thread_id = result.get("thread_id")
+        interaction_id = result.get("interaction_id")
+
+        if not thread_id:
+            logger.error("No thread_id in response")
+            return "Error: No thread_id received from PromptQL"
+
+        logger.info(f"THREAD STARTED (NO POLLING): {thread_id}")
+
+        # Format the response with thread info
+        response_text = f"Thread ID: {thread_id}"
+        if interaction_id:
+            response_text += f"\nInteraction ID: {interaction_id}"
+        response_text += f"\n\nThread started successfully. Use get_thread_status to check progress or continue_thread to add more messages."
+
+        logger.info("THREAD START RESPONSE PREPARED")
+        return response_text
+
+    except Exception as e:
+        import traceback
+        error_trace = traceback.format_exc()
+        logger.error(f"UNEXPECTED ERROR: {str(e)}")
+        logger.error(error_trace)
+        return f"Unexpected error: {str(e)}"
+
+@mcp.tool(name="continue_thread")
+async def continue_thread(thread_id: str, message: str, system_instructions: Optional[str] = None) -> str:
+    """
+    Continue an existing PromptQL thread with a new message.
+
+    Args:
+        thread_id: The ID of the thread to continue
+        message: The new message to add to the thread
+        system_instructions: Optional system instructions for the LLM
+
+    Returns:
+        Response from PromptQL for the continued conversation
+    """
+    logger.info("="*80)
+    logger.info(f"TOOL CALL: continue_thread")
+    logger.info(f"Thread ID: {thread_id}")
+    logger.info(f"Message: '{message}'")
+    logger.info("="*80)
+
+    try:
+        client = _get_promptql_client()
+
+        response = client.continue_thread(
+            thread_id=thread_id,
+            message=message,
+            system_instructions=system_instructions
+        )
+
+        if "error" in response:
+            error_message = f"Error: {response['error']}\n{response.get('details', '')}"
+            logger.error(f"ERROR RESPONSE: {error_message}")
+            return error_message
+
+        logger.info("PROCESSING PROMPTQL RESPONSE...")
+
+        # Extract the answer from the thread response format
+        answer_text = "No answer received from PromptQL."
+
+        # Look for interactions in the thread state
+        interactions = response.get("interactions", [])
+        if interactions:
+            # Get the latest interaction
+            latest_interaction = interactions[-1]
+            assistant_actions = latest_interaction.get("assistant_actions", [])
+
+            if assistant_actions:
+                # Get the last assistant action with a message (most likely the final response)
+                for action in reversed(assistant_actions):
+                    if action.get("message"):
+                        answer_text = action.get("message", "")
+                        break
+
+                # Add plan and code from actions if available
+                for action in assistant_actions:
+                    # Add plan if available
+                    plan = action.get("plan")
+                    if plan and "**Execution Plan:**" not in answer_text:
+                        logger.info("EXECUTION PLAN FOUND")
+                        answer_text += f"\n\n**Execution Plan:**\n{plan}"
+
+                    # Add code if available
+                    code = action.get("code")
+                    if code and "**Executed Code:**" not in answer_text:
+                        logger.info("EXECUTED CODE FOUND")
+                        answer_text += f"\n\n**Executed Code:**\n{code}"
+
+                    # Add code output if available
+                    code_output = action.get("code_output")
+                    if code_output and "**Code Output:**" not in answer_text:
+                        logger.info("CODE OUTPUT FOUND")
+                        answer_text += f"\n\n**Code Output:**\n{code_output}"
+
+        # Look for artifact identifiers
+        artifacts_found = []
+        if interactions:
+            for interaction in interactions:
+                assistant_actions = interaction.get("assistant_actions", [])
+                for action in assistant_actions:
+                    artifact_identifiers = action.get("artifact_identifiers", [])
+                    if artifact_identifiers:
+                        artifacts_found.extend(artifact_identifiers)
+
+        if artifacts_found:
+            logger.info(f"ARTIFACT IDENTIFIERS FOUND: {len(artifacts_found)}")
+            answer_text += f"\n\n**Artifacts Generated:** {', '.join(artifacts_found)}"
+
+        logger.info("RESPONSE PROCESSED SUCCESSFULLY")
+        return answer_text
+
+    except Exception as e:
+        logger.error(f"UNEXPECTED ERROR: {str(e)}")
+        return f"Unexpected error: {str(e)}"
+
+@mcp.tool(name="get_thread_status")
+async def get_thread_status(thread_id: str) -> str:
+    """
+    Get the current status of a PromptQL thread.
+
+    Args:
+        thread_id: The ID of the thread to check
+
+    Returns:
+        Thread status information
+    """
+    logger.info("="*80)
+    logger.info(f"TOOL CALL: get_thread_status")
+    logger.info(f"Thread ID: {thread_id}")
+    logger.info("="*80)
+
+    try:
+        client = _get_promptql_client()
+
+        result = client.get_thread_status(thread_id)
+
+        if "error" in result:
+            error_message = f"Error: {result['error']}\n{result.get('details', '')}"
+            logger.error(f"ERROR RESPONSE: {error_message}")
+            return error_message
+
+        status = result.get("status", "unknown")
+        thread_data = result.get("thread_data", {})
+        interactions_count = len(thread_data.get("interactions", []))
+
+        status_message = f"Thread {thread_id}:\n"
+        status_message += f"Status: {status}\n"
+        status_message += f"Total interactions: {interactions_count}\n"
+
+        if status == "processing":
+            status_message += "The thread is currently processing. Check again in a few moments."
+        elif status == "complete":
+            status_message += "The thread has completed processing."
+
+        logger.info(f"THREAD STATUS: {status}")
+        return status_message
+
+    except Exception as e:
+        logger.error(f"UNEXPECTED ERROR: {str(e)}")
+        return f"Unexpected error: {str(e)}"
+
+@mcp.tool(name="cancel_thread")
+async def cancel_thread(thread_id: str) -> str:
+    """
+    Cancel the processing of the latest interaction in a PromptQL thread.
+
+    Args:
+        thread_id: The ID of the thread to cancel
+
+    Returns:
+        Cancellation result message
+    """
+    logger.info("="*80)
+    logger.info(f"TOOL CALL: cancel_thread")
+    logger.info(f"Thread ID: {thread_id}")
+    logger.info("="*80)
+
+    try:
+        client = _get_promptql_client()
+
+        result = client.cancel_thread(thread_id)
+
+        if "error" in result:
+            error_message = f"Error: {result['error']}\n{result.get('details', '')}"
+            logger.error(f"ERROR RESPONSE: {error_message}")
+            return error_message
+
+        message = result.get("message", "Thread cancelled")
+
+        logger.info(f"THREAD CANCELLED: {thread_id}")
+        return f"Thread {thread_id} cancellation result: {message}"
+
+    except Exception as e:
+        logger.error(f"UNEXPECTED ERROR: {str(e)}")
+        return f"Unexpected error: {str(e)}"
 
 @mcp.prompt(name="data_analysis")
 def data_analysis_prompt(topic: str) -> str:

--- a/promptql_mcp_server/server.py
+++ b/promptql_mcp_server/server.py
@@ -32,7 +32,7 @@ def _get_promptql_client() -> PromptQLClient:
 
 
 @mcp.tool(name="setup_config")
-def setup_config(api_key: str, playground_url: str, auth_token: str) -> str:
+def setup_config(api_key: str, playground_url: str, auth_token: str) -> dict:
     """
     Configure the PromptQL MCP server with API key, playground URL, and auth token.
 
@@ -42,7 +42,7 @@ def setup_config(api_key: str, playground_url: str, auth_token: str) -> str:
         auth_token: DDN Auth Token for accessing your data
 
     Returns:
-        Success message
+        Configuration result with success status and details
     """
     logger.info("="*80)
     logger.info(f"TOOL CALL: setup_config")
@@ -59,16 +59,24 @@ def setup_config(api_key: str, playground_url: str, auth_token: str) -> str:
     config.set("auth_token", auth_token)
 
     logger.info("CONFIGURATION SAVED SUCCESSFULLY")
-    return "Configuration saved successfully."
+    return {
+        "success": True,
+        "message": "Configuration saved successfully.",
+        "configured_items": {
+            "api_key": masked_key,
+            "playground_url": playground_url,
+            "auth_token": masked_token
+        }
+    }
 
 # Add a new tool to check configuration status
 @mcp.tool(name="check_config")
-def check_config() -> str:
+def check_config() -> dict:
     """
     Check if the PromptQL MCP server is already configured with API key, playground URL, and auth token.
 
     Returns:
-        Configuration status message
+        Configuration status with detailed information about what's configured
     """
     logger.info("="*80)
     logger.info("TOOL CALL: check_config")
@@ -81,9 +89,17 @@ def check_config() -> str:
     if api_key and playground_url and auth_token:
         masked_key = api_key[:5] + "..." + api_key[-5:] if api_key else "None"
         masked_token = auth_token[:8] + "..." + auth_token[-4:] if len(auth_token) > 12 else auth_token[:4] + "..."
-        status = f"PromptQL is configured with:\nAPI Key: {masked_key}\nPlayground URL: {playground_url}\nAuth Token: {masked_token}"
         logger.info("CONFIGURATION CHECK: Already configured")
-        return status
+        return {
+            "configured": True,
+            "message": "PromptQL is fully configured",
+            "configuration": {
+                "api_key": masked_key,
+                "playground_url": playground_url,
+                "auth_token": masked_token
+            },
+            "missing_items": []
+        }
     else:
         missing = []
         if not api_key:
@@ -93,12 +109,20 @@ def check_config() -> str:
         if not auth_token:
             missing.append("Auth Token")
 
-        status = f"PromptQL is not fully configured. Missing: {', '.join(missing)}"
         logger.info(f"CONFIGURATION CHECK: Missing {', '.join(missing)}")
-        return status
+        return {
+            "configured": False,
+            "message": f"PromptQL is not fully configured. Missing: {', '.join(missing)}",
+            "configuration": {
+                "api_key": api_key[:5] + "..." + api_key[-5:] if api_key else None,
+                "playground_url": playground_url,
+                "auth_token": auth_token[:8] + "..." + auth_token[-4:] if auth_token and len(auth_token) > 12 else auth_token[:4] + "..." if auth_token else None
+            },
+            "missing_items": missing
+        }
 
 @mcp.tool(name="start_thread")
-async def start_thread(message: str, system_instructions: Optional[str] = None) -> str:
+async def start_thread(message: str, system_instructions: Optional[str] = None) -> dict:
     """
     Start a new PromptQL thread with a message and poll for completion.
 
@@ -107,7 +131,7 @@ async def start_thread(message: str, system_instructions: Optional[str] = None) 
         system_instructions: Optional system instructions for the LLM
 
     Returns:
-        Complete response from PromptQL including thread_id, interaction_id, and answer
+        Complete response from PromptQL with structured data including thread_id, interaction_id, answer, plans, code, and artifacts
     """
     logger.info("="*80)
     logger.info(f"TOOL CALL: start_thread")
@@ -125,7 +149,13 @@ async def start_thread(message: str, system_instructions: Optional[str] = None) 
         if "error" in result:
             error_message = f"Error: {result['error']}\n{result.get('details', '')}"
             logger.error(f"ERROR RESPONSE: {error_message}")
-            return error_message
+            return {
+                "success": False,
+                "error": result['error'],
+                "details": result.get('details', ''),
+                "thread_id": None,
+                "interaction_id": None
+            }
 
         # Extract thread_id and interaction_id from the result
         thread_id = result.get("thread_id")
@@ -133,12 +163,20 @@ async def start_thread(message: str, system_instructions: Optional[str] = None) 
 
         if not thread_id:
             logger.error("No thread_id in response")
-            return "Error: No thread_id received from PromptQL"
+            return {
+                "success": False,
+                "error": "No thread_id received from PromptQL",
+                "thread_id": None,
+                "interaction_id": None
+            }
 
         logger.info(f"THREAD COMPLETED: {thread_id}")
 
-        # Extract the answer from the thread response format
+        # Extract structured data from the thread response
         answer_text = "No answer received from PromptQL."
+        plans = []
+        code_blocks = []
+        code_outputs = []
 
         # Look for interactions in the thread state
         interactions = result.get("interactions", [])
@@ -154,25 +192,25 @@ async def start_thread(message: str, system_instructions: Optional[str] = None) 
                         answer_text = action.get("message", "")
                         break
 
-                # Add plan and code from actions if available
+                # Collect plans, code, and outputs from actions
                 for action in assistant_actions:
-                    # Add plan if available
+                    # Collect plan if available
                     plan = action.get("plan")
-                    if plan and "**Execution Plan:**" not in answer_text:
+                    if plan:
                         logger.info("EXECUTION PLAN FOUND")
-                        answer_text += f"\n\n**Execution Plan:**\n{plan}"
+                        plans.append(plan)
 
-                    # Add code if available
+                    # Collect code if available
                     code = action.get("code")
-                    if code and "**Executed Code:**" not in answer_text:
+                    if code:
                         logger.info("EXECUTED CODE FOUND")
-                        answer_text += f"\n\n**Executed Code:**\n{code}"
+                        code_blocks.append(code)
 
-                    # Add code output if available
+                    # Collect code output if available
                     code_output = action.get("code_output")
-                    if code_output and "**Code Output:**" not in answer_text:
+                    if code_output:
                         logger.info("CODE OUTPUT FOUND")
-                        answer_text += f"\n\n**Code Output:**\n{code_output}"
+                        code_outputs.append(code_output)
 
         # Process artifacts if available
         artifacts_found = []
@@ -187,27 +225,36 @@ async def start_thread(message: str, system_instructions: Optional[str] = None) 
 
         if artifacts_found:
             logger.info(f"ARTIFACT IDENTIFIERS FOUND: {len(artifacts_found)}")
-            answer_text += f"\n\n**Artifacts Generated:** {', '.join(artifacts_found)}"
-            answer_text += "\n\n*Note: Artifact data fetching will be implemented in a future update.*"
-
-        # Format the final response with thread info and answer
-        response_text = f"Thread ID: {thread_id}"
-        if interaction_id:
-            response_text += f"\nInteraction ID: {interaction_id}"
-        response_text += f"\n\n{answer_text}"
 
         logger.info("FINAL RESPONSE PREPARED")
-        return response_text
+        return {
+            "success": True,
+            "thread_id": thread_id,
+            "interaction_id": interaction_id,
+            "answer": answer_text,
+            "plans": plans,
+            "code_blocks": code_blocks,
+            "code_outputs": code_outputs,
+            "artifacts": artifacts_found,
+            "interactions_count": len(interactions),
+            "raw_response": result
+        }
 
     except Exception as e:
         import traceback
         error_trace = traceback.format_exc()
         logger.error(f"UNEXPECTED ERROR: {str(e)}")
         logger.error(error_trace)
-        return f"Unexpected error: {str(e)}"
+        return {
+            "success": False,
+            "error": f"Unexpected error: {str(e)}",
+            "error_trace": error_trace,
+            "thread_id": None,
+            "interaction_id": None
+        }
 
 @mcp.tool(name="start_thread_without_polling")
-async def start_thread_without_polling(message: str, system_instructions: Optional[str] = None) -> str:
+async def start_thread_without_polling(message: str, system_instructions: Optional[str] = None) -> dict:
     """
     Start a new PromptQL thread with a message without waiting for completion.
 
@@ -216,7 +263,7 @@ async def start_thread_without_polling(message: str, system_instructions: Option
         system_instructions: Optional system instructions for the LLM
 
     Returns:
-        Thread ID and interaction ID for the started thread
+        Thread ID and interaction ID for the started thread with status information
     """
     logger.info("="*80)
     logger.info(f"TOOL CALL: start_thread_without_polling")
@@ -234,7 +281,13 @@ async def start_thread_without_polling(message: str, system_instructions: Option
         if "error" in result:
             error_message = f"Error: {result['error']}\n{result.get('details', '')}"
             logger.error(f"ERROR RESPONSE: {error_message}")
-            return error_message
+            return {
+                "success": False,
+                "error": result['error'],
+                "details": result.get('details', ''),
+                "thread_id": None,
+                "interaction_id": None
+            }
 
         # Extract thread_id and interaction_id from the result
         thread_id = result.get("thread_id")
@@ -242,28 +295,40 @@ async def start_thread_without_polling(message: str, system_instructions: Option
 
         if not thread_id:
             logger.error("No thread_id in response")
-            return "Error: No thread_id received from PromptQL"
+            return {
+                "success": False,
+                "error": "No thread_id received from PromptQL",
+                "thread_id": None,
+                "interaction_id": None
+            }
 
         logger.info(f"THREAD STARTED (NO POLLING): {thread_id}")
 
-        # Format the response with thread info
-        response_text = f"Thread ID: {thread_id}"
-        if interaction_id:
-            response_text += f"\nInteraction ID: {interaction_id}"
-        response_text += f"\n\nThread started successfully. Use get_thread_status to check progress or continue_thread to add more messages."
-
         logger.info("THREAD START RESPONSE PREPARED")
-        return response_text
+        return {
+            "success": True,
+            "thread_id": thread_id,
+            "interaction_id": interaction_id,
+            "message": "Thread started successfully. Use get_thread_status to check progress or continue_thread to add more messages.",
+            "status": "started",
+            "polling": False
+        }
 
     except Exception as e:
         import traceback
         error_trace = traceback.format_exc()
         logger.error(f"UNEXPECTED ERROR: {str(e)}")
         logger.error(error_trace)
-        return f"Unexpected error: {str(e)}"
+        return {
+            "success": False,
+            "error": f"Unexpected error: {str(e)}",
+            "error_trace": error_trace,
+            "thread_id": None,
+            "interaction_id": None
+        }
 
 @mcp.tool(name="continue_thread")
-async def continue_thread(thread_id: str, message: str, system_instructions: Optional[str] = None) -> str:
+async def continue_thread(thread_id: str, message: str, system_instructions: Optional[str] = None) -> dict:
     """
     Continue an existing PromptQL thread with a new message.
 
@@ -273,7 +338,7 @@ async def continue_thread(thread_id: str, message: str, system_instructions: Opt
         system_instructions: Optional system instructions for the LLM
 
     Returns:
-        Response from PromptQL for the continued conversation
+        Structured response from PromptQL for the continued conversation with thread data, answer, plans, code, and artifacts
     """
     logger.info("="*80)
     logger.info(f"TOOL CALL: continue_thread")
@@ -293,12 +358,21 @@ async def continue_thread(thread_id: str, message: str, system_instructions: Opt
         if "error" in response:
             error_message = f"Error: {response['error']}\n{response.get('details', '')}"
             logger.error(f"ERROR RESPONSE: {error_message}")
-            return error_message
+            return {
+                "success": False,
+                "error": response['error'],
+                "details": response.get('details', ''),
+                "thread_id": thread_id,
+                "interaction_id": None
+            }
 
         logger.info("PROCESSING PROMPTQL RESPONSE...")
 
-        # Extract the answer from the thread response format
+        # Extract structured data from the thread response
         answer_text = "No answer received from PromptQL."
+        plans = []
+        code_blocks = []
+        code_outputs = []
 
         # Look for interactions in the thread state
         interactions = response.get("interactions", [])
@@ -314,25 +388,25 @@ async def continue_thread(thread_id: str, message: str, system_instructions: Opt
                         answer_text = action.get("message", "")
                         break
 
-                # Add plan and code from actions if available
+                # Collect plans, code, and outputs from actions
                 for action in assistant_actions:
-                    # Add plan if available
+                    # Collect plan if available
                     plan = action.get("plan")
-                    if plan and "**Execution Plan:**" not in answer_text:
+                    if plan:
                         logger.info("EXECUTION PLAN FOUND")
-                        answer_text += f"\n\n**Execution Plan:**\n{plan}"
+                        plans.append(plan)
 
-                    # Add code if available
+                    # Collect code if available
                     code = action.get("code")
-                    if code and "**Executed Code:**" not in answer_text:
+                    if code:
                         logger.info("EXECUTED CODE FOUND")
-                        answer_text += f"\n\n**Executed Code:**\n{code}"
+                        code_blocks.append(code)
 
-                    # Add code output if available
+                    # Collect code output if available
                     code_output = action.get("code_output")
-                    if code_output and "**Code Output:**" not in answer_text:
+                    if code_output:
                         logger.info("CODE OUTPUT FOUND")
-                        answer_text += f"\n\n**Code Output:**\n{code_output}"
+                        code_outputs.append(code_output)
 
         # Look for artifact identifiers
         artifacts_found = []
@@ -346,25 +420,53 @@ async def continue_thread(thread_id: str, message: str, system_instructions: Opt
 
         if artifacts_found:
             logger.info(f"ARTIFACT IDENTIFIERS FOUND: {len(artifacts_found)}")
-            answer_text += f"\n\n**Artifacts Generated:** {', '.join(artifacts_found)}"
+
+        # Extract interaction_id from the latest interaction
+        interaction_id = None
+        if interactions:
+            interaction_id = interactions[-1].get("interaction_id")
 
         logger.info("RESPONSE PROCESSED SUCCESSFULLY")
-        return answer_text
+        return {
+            "success": True,
+            "thread_id": thread_id,
+            "interaction_id": interaction_id,
+            "answer": answer_text,
+            "plans": plans,
+            "code_blocks": code_blocks,
+            "code_outputs": code_outputs,
+            "artifacts": artifacts_found,
+            "interactions_count": len(interactions),
+            "raw_response": response
+        }
 
     except Exception as e:
         logger.error(f"UNEXPECTED ERROR: {str(e)}")
-        return f"Unexpected error: {str(e)}"
+        return {
+            "success": False,
+            "error": f"Unexpected error: {str(e)}",
+            "thread_id": thread_id,
+            "interaction_id": None
+        }
 
 @mcp.tool(name="get_thread_status")
-async def get_thread_status(thread_id: str) -> str:
+async def get_thread_status(thread_id: str) -> dict:
     """
-    Get the current status of a PromptQL thread.
+    Get the current status of a PromptQL thread with detailed information.
 
     Args:
         thread_id: The ID of the thread to check
 
     Returns:
-        Thread status information
+        Comprehensive thread status as structured data including:
+        - Thread status (processing/complete)
+        - Total interactions count
+        - Detailed breakdown of each interaction:
+          * User messages with timestamps
+          * Assistant actions with status
+          * Messages, plans, code, and code output
+          * Artifact identifiers
+          * Timing information (start/end timestamps)
     """
     logger.info("="*80)
     logger.info(f"TOOL CALL: get_thread_status")
@@ -379,30 +481,117 @@ async def get_thread_status(thread_id: str) -> str:
         if "error" in result:
             error_message = f"Error: {result['error']}\n{result.get('details', '')}"
             logger.error(f"ERROR RESPONSE: {error_message}")
-            return error_message
+            return {
+                "success": False,
+                "error": result['error'],
+                "details": result.get('details', ''),
+                "thread_id": thread_id
+            }
 
         status = result.get("status", "unknown")
         thread_data = result.get("thread_data", {})
-        interactions_count = len(thread_data.get("interactions", []))
+        interactions = thread_data.get("interactions", [])
+        interactions_count = len(interactions)
 
-        status_message = f"Thread {thread_id}:\n"
-        status_message += f"Status: {status}\n"
-        status_message += f"Total interactions: {interactions_count}\n"
+        # Build structured response
+        response_data = {
+            "success": True,
+            "thread_id": thread_id,
+            "status": status,
+            "interactions_count": interactions_count,
+            "message": f"Thread {thread_id} is {status}",
+            "interactions": []
+        }
 
-        if status == "processing":
-            status_message += "The thread is currently processing. Check again in a few moments."
-        elif status == "complete":
-            status_message += "The thread has completed processing."
+        # Add detailed information about interactions and assistant actions
+        if interactions:
+            for i, interaction in enumerate(interactions, 1):
+                interaction_data = {
+                    "interaction_number": i,
+                    "interaction_id": interaction.get("interaction_id"),
+                    "user_message": {},
+                    "assistant_actions": []
+                }
+
+                # Process user message if available
+                user_message_data = interaction.get("user_message", {})
+                if user_message_data:
+                    if isinstance(user_message_data, dict):
+                        interaction_data["user_message"] = {
+                            "message": user_message_data.get("message", ""),
+                            "timestamp": user_message_data.get("timestamp", ""),
+                            "timezone": user_message_data.get("timezone", ""),
+                            "uploads": user_message_data.get("uploads", [])
+                        }
+                    else:
+                        # Fallback for simple string format
+                        interaction_data["user_message"] = {
+                            "message": str(user_message_data),
+                            "timestamp": "",
+                            "timezone": "",
+                            "uploads": []
+                        }
+
+                # Process assistant actions
+                assistant_actions = interaction.get("assistant_actions", [])
+
+                for j, action in enumerate(assistant_actions, 1):
+                    action_data = {
+                        "action_number": j,
+                        "action_id": action.get("action_id"),
+                        "status": action.get("status", "unknown"),
+                        "message": action.get("message", ""),
+                        "plan": action.get("plan", ""),
+                        "code": {},
+                        "code_output": action.get("code_output", ""),
+                        "artifacts": action.get("artifact_identifiers", []),
+                        "timing": {
+                            "created_timestamp": action.get("created_timestamp", ""),
+                            "response_start_timestamp": action.get("response_start_timestamp", ""),
+                            "action_end_timestamp": action.get("action_end_timestamp", ""),
+                            "llm_call_start_timestamp": action.get("llm_call_start_timestamp", ""),
+                            "llm_call_end_timestamp": action.get("llm_call_end_timestamp", "")
+                        }
+                    }
+
+                    # Process code data if available
+                    code_data = action.get("code", {})
+                    if code_data:
+                        if isinstance(code_data, dict):
+                            action_data["code"] = {
+                                "code_block_id": code_data.get("code_block_id", ""),
+                                "code": code_data.get("code", ""),
+                                "query_plan": code_data.get("query_plan", ""),
+                                "execution_start_timestamp": code_data.get("execution_start_timestamp"),
+                                "execution_end_timestamp": code_data.get("execution_end_timestamp"),
+                                "output": code_data.get("output"),
+                                "error": code_data.get("error"),
+                                "sql_statements": code_data.get("sql_statements", [])
+                            }
+                        else:
+                            # Fallback for simple string format
+                            action_data["code"] = {"code": str(code_data)}
+
+                    interaction_data["assistant_actions"].append(action_data)
+
+                response_data["interactions"].append(interaction_data)
+
+        # Add raw thread data for advanced use cases
+        response_data["raw_thread_data"] = thread_data
 
         logger.info(f"THREAD STATUS: {status}")
-        return status_message
+        return response_data
 
     except Exception as e:
         logger.error(f"UNEXPECTED ERROR: {str(e)}")
-        return f"Unexpected error: {str(e)}"
+        return {
+            "success": False,
+            "error": f"Unexpected error: {str(e)}",
+            "thread_id": thread_id
+        }
 
 @mcp.tool(name="cancel_thread")
-async def cancel_thread(thread_id: str) -> str:
+async def cancel_thread(thread_id: str) -> dict:
     """
     Cancel the processing of the latest interaction in a PromptQL thread.
 
@@ -410,7 +599,7 @@ async def cancel_thread(thread_id: str) -> str:
         thread_id: The ID of the thread to cancel
 
     Returns:
-        Cancellation result message
+        Cancellation result with success status and details
     """
     logger.info("="*80)
     logger.info(f"TOOL CALL: cancel_thread")
@@ -425,16 +614,86 @@ async def cancel_thread(thread_id: str) -> str:
         if "error" in result:
             error_message = f"Error: {result['error']}\n{result.get('details', '')}"
             logger.error(f"ERROR RESPONSE: {error_message}")
-            return error_message
+            return {
+                "success": False,
+                "error": result['error'],
+                "details": result.get('details', ''),
+                "thread_id": thread_id
+            }
 
         message = result.get("message", "Thread cancelled")
 
         logger.info(f"THREAD CANCELLED: {thread_id}")
-        return f"Thread {thread_id} cancellation result: {message}"
+        return {
+            "success": True,
+            "thread_id": thread_id,
+            "message": message,
+            "action": "cancelled",
+            "raw_response": result
+        }
 
     except Exception as e:
         logger.error(f"UNEXPECTED ERROR: {str(e)}")
-        return f"Unexpected error: {str(e)}"
+        return {
+            "success": False,
+            "error": f"Unexpected error: {str(e)}",
+            "thread_id": thread_id
+        }
+
+@mcp.tool(name="get_artifact")
+def get_artifact(thread_id: str, artifact_id: str) -> dict:
+    """
+    Get artifact data from a specific thread.
+
+    Args:
+        thread_id: The ID of the thread containing the artifact
+        artifact_id: The ID of the artifact to retrieve
+
+    Returns:
+        Dictionary containing artifact data, metadata, and retrieval status
+    """
+    logger.info("="*80)
+    logger.info(f"TOOL CALL: get_artifact")
+    logger.info(f"Thread ID: {thread_id}")
+    logger.info(f"Artifact ID: {artifact_id}")
+    logger.info("="*80)
+
+    try:
+        client = _get_promptql_client()
+        response_data = client.get_artifact(thread_id, artifact_id)
+
+        if "error" in response_data:
+            logger.error(f"ERROR getting artifact: {response_data['error']}")
+            return {
+                "success": False,
+                "error": response_data["error"],
+                "details": response_data.get("details", ""),
+                "thread_id": thread_id,
+                "artifact_id": artifact_id
+            }
+
+        logger.info(f"ARTIFACT RETRIEVED: {artifact_id}")
+        logger.info(f"Content Type: {response_data.get('content_type', 'unknown')}")
+        logger.info(f"Size: {response_data.get('size', 0)} bytes")
+
+        return {
+            "success": True,
+            "thread_id": thread_id,
+            "artifact_id": artifact_id,
+            "content_type": response_data.get("content_type"),
+            "size": response_data.get("size"),
+            "data": response_data.get("data"),
+            "message": f"Artifact {artifact_id} retrieved successfully from thread {thread_id}",
+            "raw_response": response_data
+        }
+    except Exception as e:
+        logger.error(f"ERROR in get_artifact tool: {str(e)}")
+        return {
+            "success": False,
+            "error": f"Get artifact error: {str(e)}",
+            "thread_id": thread_id,
+            "artifact_id": artifact_id
+        }
 
 @mcp.prompt(name="data_analysis")
 def data_analysis_prompt(topic: str) -> str:


### PR DESCRIPTION
Enhance PromptQL MCP server with thread management features

- Use async APIs for threads - https://promptql.io/docs/promptql-apis/threads-api/#threads-v2-api
- Introduced new tools for managing conversation threads: start_thread, start_thread_without_polling, continue_thread, get_thread_status, and cancel_thread.
- Updated README.md to include detailed usage examples for multi-turn conversation and thread management.
- Refactored existing ask_question tool to start threads and handle responses in a more structured way.
- Improved error handling and logging for thread operations.
- Added functionality to process system instructions and manage thread interactions effectively.
- return structured configuration results instead of plain strings for all the mcp tools exposed
- Add artifact retrieval functionality
- change the thread/status api to support SSE events
- Add support for private and public auth-mode
  - for private auth mode - `x-hasura-ddn-token` header is set
  - for public auth mode - `Auth-Token` header is set
  - At the moment, that's the only thing supported